### PR TITLE
Fix: Add null check before accessing FirebaseAuth.currentUser.uid

### DIFF
--- a/lib/new_ui/screens/login_screen/login_screen.dart
+++ b/lib/new_ui/screens/login_screen/login_screen.dart
@@ -67,8 +67,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
       if (userModel != null) {
         print("print6");
-        ref.watch(authProvider.notifier).setupFCMNotifications(ref,
-            userModel.studentModel, FirebaseAuth.instance.currentUser!.uid);
+        final currentUser = FirebaseAuth.instance.currentUser;
+        if (currentUser != null) {
+          ref.watch(authProvider.notifier).setupFCMNotifications(ref,
+              userModel.studentModel, currentUser.uid);
+        }
 
         // if (studentModel.updateCount != null &&
         //     studentModel.updateCount! > 0) {


### PR DESCRIPTION
## Bug Fix: Missing null check before accessing currentUser.uid

### Problem
In `login_screen.dart`, the code accesses `FirebaseAuth.instance.currentUser!.uid` without checking if `currentUser` is null. This can cause a null pointer exception if the user is not authenticated or the session has expired.

### Solution
Added a null check for `FirebaseAuth.instance.currentUser` before accessing the `.uid` property. The `setupFCMNotifications` method is now only called when both `userModel` and `currentUser` are valid.

### Changes
- Store `FirebaseAuth.instance.currentUser` in a variable
- Add null check before accessing `.uid`
- Only call `setupFCMNotifications` when currentUser is not null

### Testing
This fix prevents crashes when:
- User session expires
- Authentication state is not properly initialized
- Network issues cause auth state to be null

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.